### PR TITLE
Use root user and group ownership for installed udev rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ These udev rules set all Nordic Semiconductor devices as readable/writable by al
 This repo contains the files needed for creating a .deb package for installing the udev rules for nRF devices. To create the package in a Debian-based linux system:
 
 ```
-dpkg-deb -b nrf-udev_1.0.1-all
+dpkg-deb --root-owner-group -b nrf-udev_1.0.1-all
 ```


### PR DESCRIPTION
This PR updates packaging instructions to use root user and group ownership for the installed udev rules.

Without `--root-owner-group`:

```
# dpkg-deb -b nrf-udev_1.0.1-all
dpkg-deb: building package 'nrf-udev' in 'nrf-udev_1.0.1-all.deb'.

# sudo dpkg -i nrf-udev_1.0.1-all.deb
[sudo] password for patrick:
Selecting previously unselected package nrf-udev.
(Reading database ... 391121 files and directories currently installed.)
Preparing to unpack nrf-udev_1.0.1-all.deb ...
Unpacking nrf-udev (1.0.1) ...
Setting up nrf-udev (1.0.1) ...
Reloading udev rules...

# ls -l /lib/udev/rules.d/*nrf*
-rw-r--r-- 1 patrick patrick    493 janv. 18 08:49 71-nrf.rules
-rw-r--r-- 1 patrick patrick    189 janv. 18 08:49 99-mm-nrf-blacklist.rules
```

With `--root-owner-group`:

```
# dpkg-deb --root-owner-group -b nrf-udev_1.0.1-all
dpkg-deb: building package 'nrf-udev' in 'nrf-udev_1.0.1-all.deb'.

# sudo dpkg -i nrf-udev_1.0.1-all.deb
(Reading database ... 391123 files and directories currently installed.)
Preparing to unpack nrf-udev_1.0.1-all.deb ...
Unpacking nrf-udev (1.0.1) over (1.0.1) ...
Reloading udev rules...
Setting up nrf-udev (1.0.1) ...
Reloading udev rules...

# ls -l /lib/udev/rules.d/*nrf*
-rw-r--r-- 1 root root 493 janv. 18 08:49 /lib/udev/rules.d/71-nrf.rules
-rw-r--r-- 1 root root 189 janv. 18 08:49 /lib/udev/rules.d/99-mm-nrf-blacklist.rules
```